### PR TITLE
refactor: 중복된 parserOptions 제거

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,12 +12,6 @@ module.exports = {
   },
   plugins: ["@typescript-eslint", "react-hooks", "prettier", "react"],
   parser: "@typescript-eslint/parser",
-  parserOptions: {
-    sourceType: "module",
-    ecmaFeatures: {
-      jsx: true
-    }
-  },
   rules: {
     "react-hooks/rules-of-hooks": 2,
     "react-hooks/exhaustive-deps": 2


### PR DESCRIPTION
## PR에 대한 요약
eslint 설정 파일에서, `parserOptions` 이 반복되어 두번 정의되었습니다. 

## 해결법
동일한 설정에서 더 상세히 설정된 부분을 선택하고, 나머지는 제거합니다. 

정의 : `ecmaVersion: 2018`,
디폴트 : `ecmaVersion: 5` (참고: [링크](https://eslint.org/docs/user-guide/configuring#specifying-parser-options))
